### PR TITLE
Added missing lang and json entries

### DIFF
--- a/common/src/main/java/com/github/teamfusion/summonerscrolls/SummonerScrolls.java
+++ b/common/src/main/java/com/github/teamfusion/summonerscrolls/SummonerScrolls.java
@@ -23,7 +23,7 @@ public class SummonerScrolls {
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_NAME);
 
     public static final CreativeModeTab SCROLLS_TAB = CreativeTabRegistry.create(new ResourceLocation(MOD_ID, "scrolls_tab"), () ->
-            new ItemStack(SummonerScrollsItems.ZOMBIE_SCROLL.get()));
+            new ItemStack(SummonerScrollsItems.ENHANCEMENT_SCROLL.get()));
     
     public static void commonInitialize() {
         LOGGER.info("Initializing {}", MOD_NAME);

--- a/common/src/main/java/com/github/teamfusion/summonerscrolls/entity/HuskSummon.java
+++ b/common/src/main/java/com/github/teamfusion/summonerscrolls/entity/HuskSummon.java
@@ -195,7 +195,11 @@ public class HuskSummon extends Husk implements Summon {
 
     public static AttributeSupplier.Builder createSummonAttributes() {
         //todo: Costs 20 XP to summon. 5 Durability to use, burn enemy
-        return Monster.createMonsterAttributes().add(Attributes.FOLLOW_RANGE, 35.0).add(Attributes.MOVEMENT_SPEED, 0.3).add(Attributes.ATTACK_DAMAGE, 6.0).add(Attributes.ARMOR, 2.0).add(Attributes.SPAWN_REINFORCEMENTS_CHANCE);
+        return Monster.createMonsterAttributes().add(Attributes.FOLLOW_RANGE, 35.0)
+                .add(Attributes.MOVEMENT_SPEED, 0.4)
+                .add(Attributes.ATTACK_DAMAGE, 6.0)
+                .add(Attributes.ARMOR, 2.0)
+                .add(Attributes.SPAWN_REINFORCEMENTS_CHANCE);
     }
 
     @Override

--- a/common/src/main/java/com/github/teamfusion/summonerscrolls/entity/ZombieSummon.java
+++ b/common/src/main/java/com/github/teamfusion/summonerscrolls/entity/ZombieSummon.java
@@ -194,6 +194,10 @@ public class ZombieSummon extends Zombie implements Summon {
     }
 
     public static AttributeSupplier.Builder createSummonAttributes() {
-        return Monster.createMonsterAttributes().add(Attributes.FOLLOW_RANGE, 35.0).add(Attributes.MOVEMENT_SPEED, 0.3).add(Attributes.ATTACK_DAMAGE, 3.0).add(Attributes.ARMOR, 2.0).add(Attributes.SPAWN_REINFORCEMENTS_CHANCE);
+        return Monster.createMonsterAttributes().add(Attributes.FOLLOW_RANGE, 35.0)
+                .add(Attributes.MOVEMENT_SPEED, 0.3)
+                .add(Attributes.ATTACK_DAMAGE, 3.0)
+                .add(Attributes.ARMOR, 2.0)
+                .add(Attributes.SPAWN_REINFORCEMENTS_CHANCE);
     }
 }

--- a/common/src/main/java/com/github/teamfusion/summonerscrolls/item/SummonerScrollsItems.java
+++ b/common/src/main/java/com/github/teamfusion/summonerscrolls/item/SummonerScrollsItems.java
@@ -16,6 +16,8 @@ import java.util.function.Supplier;
 public class SummonerScrollsItems {
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(SummonerScrolls.MOD_ID, Registry.ITEM_REGISTRY);
 
+    public static final RegistrySupplier<Item> ENHANCEMENT_SCROLL = ITEMS.register("enhancement_summoner_scroll", () ->  new Item(new Item.Properties().stacksTo(16).tab(SummonerScrolls.SCROLLS_TAB)));
+
     /* Mob Scrolls - Tier 1 */
     public static final RegistrySupplier<Item> ZOMBIE_SCROLL = ITEMS.register("zombie_summoner_scroll", () ->
             new ScrollItem(SummonerScrollsEnchantments.ZOMBIE_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
@@ -39,14 +41,14 @@ public class SummonerScrollsItems {
             new ScrollItem(SummonerScrollsEnchantments.PIGLIN_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
 
     /* Mob Scrolls - Tier 3 */
-//    public static final RegistrySupplier<Item> SHULKERMAN_SCROLL = ITEMS.register("shulkerman_summoner_scroll", () ->
-//            new ScrollItem(SummonerScrollsEnchantments.SHULKERMAN_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
     public static final RegistrySupplier<Item> CREEPER_SCROLL = ITEMS.register("creeper_summoner_scroll", () ->
             new ScrollItem(SummonerScrollsEnchantments.CREEPER_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
     public static final RegistrySupplier<Item> CHARGED_CREEPER_SCROLL = ITEMS.register("charged_creeper_summoner_scroll", () ->
             new ScrollItem(SummonerScrollsEnchantments.CHARGED_CREEPER_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
     public static final RegistrySupplier<Item> PIGLIN_BRUTE_SCROLL = ITEMS.register("piglin_brute_summoner_scroll", () ->
             new ScrollItem(SummonerScrollsEnchantments.PIGLIN_BRUTE_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
+//    public static final RegistrySupplier<Item> SHULKERMAN_SCROLL = ITEMS.register("shulkerman_summoner_scroll", () ->
+//            new ScrollItem(SummonerScrollsEnchantments.SHULKERMAN_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
     public static final RegistrySupplier<Item> IRON_GOLEM_SCROLL = ITEMS.register("iron_golem_summoner_scroll", () ->
             new ScrollItem(SummonerScrollsEnchantments.IRON_GOLEM_SCROLL_ENCHANTMENT, new Item.Properties().stacksTo(1).tab(SummonerScrolls.SCROLLS_TAB)));
 

--- a/common/src/main/resources/assets/summonerscrolls/lang/en_us.json
+++ b/common/src/main/resources/assets/summonerscrolls/lang/en_us.json
@@ -1,22 +1,60 @@
 {
-  "itemGroup.summonerscrolls.scrolls_tab": "Summoners Scrolls",
+  "itemGroup.summonerscrolls.scrolls_tab": "Summoner Scrolls",
+
+  "item.summonerscrolls.enhancement_summoner_scroll": "Summon Enhancement Scroll",
 
   "item.summonerscrolls.zombie_summoner_scroll": "Zombie Summoner Scroll",
   "item.summonerscrolls.skeleton_summoner_scroll": "Skeleton Summoner Scroll",
   "item.summonerscrolls.spider_summoner_scroll": "Spider Summoner Scroll",
+  "item.summonerscrolls.bee_summoner_scroll": "Bee Swarm Summoner Scroll",
+
+  "item.summonerscrolls.husk_summoner_scroll": "Husk Summoner Scroll",
+  "item.summonerscrolls.stray_summoner_scroll": "Stray Summoner Scroll",
+  "item.summonerscrolls.cave_spider_summoner_scroll": "Cave Spider Summoner Scroll",
   "item.summonerscrolls.enderman_summoner_scroll": "Enderman Summoner Scroll",
+  "item.summonerscrolls.piglin_summoner_scroll": "Piglin Summoner Scroll",
+
   "item.summonerscrolls.creeper_summoner_scroll": "Creeper Summoner Scroll",
+  "item.summonerscrolls.charged_creeper_summoner_scroll": "Charged Creeper Summoner Scroll",
+  "item.summonerscrolls.piglin_brute_summoner_scroll": "Piglin Brute Summoner Scroll",
+  "item.summonerscrolls.shulkerman_summoner_scroll": "Shulkerman Summoner Scroll",
+  "item.summonerscrolls.iron_golem_summoner_scroll": "Iron Golem Summoner Scroll",
+
   "item.summonerscrolls.invisible_summon_light": "Invisible Summon Light",
 
-  "enchantment.summonerscrolls.zombie_scroll": "Zombie Scroll",
-  "enchantment.summonerscrolls.skeleton_scroll": "Skeleton Scroll",
-  "enchantment.summonerscrolls.spider_scroll": "Spider Scroll",
-  "enchantment.summonerscrolls.enderman_scroll": "Enderman Scroll",
-  "enchantment.summonerscrolls.creeper_scroll": "Creeper Scroll",
+
+  "enchantment.summonerscrolls.zombie_scroll": "Zombie Summon",
+  "enchantment.summonerscrolls.skeleton_scroll": "Skeleton Summon",
+  "enchantment.summonerscrolls.spider_scroll": "Spider Summon",
+  "enchantment.summonerscrolls.bee_scroll": "Spider Summon",
+
+  "enchantment.summonerscrolls.husk_scroll": "Husk Summon",
+  "enchantment.summonerscrolls.stray_scroll": "Stray Summon",
+  "enchantment.summonerscrolls.cave_spider_scroll": "Cave Spider Summon",
+  "enchantment.summonerscrolls.enderman_scroll": "Enderman Summon",
+  "enchantment.summonerscrolls.piglin_scroll": "Piglin Summon",
+
+  "enchantment.summonerscrolls.creeper_scroll": "Creeper Summon",
+  "enchantment.summonerscrolls.charged_creeper_scroll": "Charged Creeper Summon",
+  "enchantment.summonerscrolls.piglin_brute_scroll": "Piglin Brute Summon",
+  "enchantment.summonerscrolls.shulkerman_scroll": "Shulkerman Summon",
+  "enchantment.summonerscrolls.iron_golem_scroll": "Iron Golem Summon",
+
 
   "entity.summonerscrolls.zombie_summon": "Zombie Summon",
   "entity.summonerscrolls.skeleton_summon": "Skeleton Summon",
   "entity.summonerscrolls.spider_summon": "Spider Summon",
-  "entity.summonerscrolls.enderman_summon": "Enderman Summon",
-  "entity.summonerscrolls.creeper_summon": "Creeper Summon"
+  "entity.summonerscrolls.bee_summon": "Bee Summon",
+
+  "entity.summonerscrolls.husk_scroll": "Husk Summon",
+  "entity.summonerscrolls.stray_scroll": "Stray Summon",
+  "entity.summonerscrolls.cave_spider_scroll": "Cave Spider Summon",
+  "entity.summonerscrolls.enderman_scroll": "Enderman Summon",
+  "entity.summonerscrolls.piglin_scroll": "Piglin Summon",
+
+  "entity.summonerscrolls.creeper_scroll": "Creeper Summon",
+  "entity.summonerscrolls.charged_creeper_scroll": "Charged Creeper Summon",
+  "entity.summonerscrolls.piglin_brute_scroll": "Piglin Brute Summon",
+  "entity.summonerscrolls.shulkerman_scroll": "Shulkerman Summon",
+  "entity.summonerscrolls.iron_golem_scroll": "Iron Golem Summon"
 }

--- a/common/src/main/resources/assets/summonerscrolls/models/item/bee_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/bee_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/bee_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/cave_spider_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/cave_spider_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/cave_spider_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/charged_creeper_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/charged_creeper_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/charged_creeper_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/enhancement_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/enhancement_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/enhancement_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/husk_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/husk_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/husk_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/iron_golem_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/iron_golem_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/iron_golem_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/piglin_brute_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/piglin_brute_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/piglin_brute_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/piglin_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/piglin_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/piglin_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/shulkerman_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/shulkerman_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/shulkerman_summoner_scroll"
+  }
+}

--- a/common/src/main/resources/assets/summonerscrolls/models/item/stray_summoner_scroll.json
+++ b/common/src/main/resources/assets/summonerscrolls/models/item/stray_summoner_scroll.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "summonerscrolls:item/stray_summoner_scroll"
+  }
+}


### PR DESCRIPTION
Now every texture and name displays correctly!

- Fixed inconsistent ordering of lang entries to match the Google Doc
- Changed the Enchantments' suffix from 'Scroll' to 'Summon' in lang (e.g. Enchanted Book - Zombie Summon)
- Fixed the tab being called 'Summoners Scrolls' mistakenly
- Changed the tab's icon to the Enhancement Scroll

- Added the Enhancement Scroll, which stacks up to 16
- Fixed Husk Summons moving at 0.3 speed (now they move at 0.4 speed)